### PR TITLE
Corrected minor typo in documentation

### DIFF
--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.Graphics.Colour
         }
 
         /// <summary>
-        /// Creates a ColourInfo with a horizontal gradient.
+        /// Creates a ColourInfo with a vertical gradient.
         /// </summary>
         /// <param name="c1">The top colour of the gradient.</param>
         /// <param name="c2">The bottom colour of the gradient.</param>


### PR DESCRIPTION
As the title said, corrected "horizontal gradient" documentation

![image](https://user-images.githubusercontent.com/15872787/42429339-04102aac-836b-11e8-894a-d290bc026051.png)